### PR TITLE
Fix up numeric and string versions

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,3 +1,7 @@
+0.10.4
+------
+* Fix up RB_LDAP_MINOR_VERSION and RB_LDAP_PATCH_VERSION to agree with RB_LDAP_VERSION
+
 0.10.3
 -----
 * Cast (rb_block_call_func_t) per https://github.com/bearded/ruby-ldap/issues/47#issuecomment-1645066553

--- a/rbldap.h
+++ b/rbldap.h
@@ -25,10 +25,10 @@
 # define LDAP_OPT_ERROR   (-1)
 #endif
 
-#define RB_LDAP_MAJOR_VERSION 0
-#define RB_LDAP_MINOR_VERSION 9
-#define RB_LDAP_PATCH_VERSION 20
-#define RB_LDAP_VERSION "0.10.3"
+#define RB_LDAP_MAJOR_VERSION 0  /* Must agree with RB_LDAP_VERSION below */
+#define RB_LDAP_MINOR_VERSION 10 /* Must agree with RB_LDAP_VERSION below */
+#define RB_LDAP_PATCH_VERSION 4  /* Must agree with RB_LDAP_VERSION below */
+#define RB_LDAP_VERSION "0.10.4" /* This must agree with the numeric version parts above */
 
 #define LDAP_GET_OPT_MAX_BUFFER_SIZE    (1024)	/* >= sizeof(LDAPAPIInfo) */
 

--- a/ruby-ldap3.gemspec
+++ b/ruby-ldap3.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'ruby-ldap3'
-  s.version = '0.10.3'
+  s.version = '0.10.4'
   s.summary = 'Ruby/LDAP is an extension module for Ruby'
   s.description = <<-EOF
 It provides the interface to some LDAP libraries (e.g. OpenLDAP, Netscape SDK and Active Directory). The common API for application development is described in RFC1823 and is supported by Ruby/LDAP.

--- a/ruby-ldap3.spec
+++ b/ruby-ldap3.spec
@@ -5,7 +5,7 @@
 %define rdoc %( type rdoc > /dev/null && echo 1 || echo 0 )
 Summary: LDAP API (RFC1823) library module for Ruby.
 Name: ruby-ldap3
-Version: 0.10.3
+Version: 0.10.4
 Release: 1
 License: BSD-3-Clause
 Group: Applications/Ruby


### PR DESCRIPTION
This fixes the numeric versions, which are available as:

LDAP::MAJOR_VERSION
LDAP::MINOR_VERSION
LDAP::PATCH_VERSION

They should now agree with the string version:

LDAP::VERSION